### PR TITLE
[ADD] #3 replace odoo core's overtime calculation with _report_theoretical_time

### DIFF
--- a/verdigado_attendance/__manifest__.py
+++ b/verdigado_attendance/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Verdigado HR Attendance",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.0.1",
     "category": "Human Resources",
     "website": "https://github.com/OCA/hr-attendance",
     "author": "verdigado eG",
@@ -12,6 +12,7 @@
     "depends": ["hr_attendance", "hr_attendance_report_theoretical_time"],
     "data": [
         "data/res.lang.csv",
+        "data/ir_cron.xml",
         "security/ir.model.access.csv",
         "security/hr_attendance_rule_attendance_manager.xml",
         "views/hr_attendance_view.xml",

--- a/verdigado_attendance/data/ir_cron.xml
+++ b/verdigado_attendance/data/ir_cron.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf8" ?>
+<odoo>
+    <record id="cron_update_overtime" model="ir.cron">
+        <field name="name">Update overtime</field>
+        <field name="numbercall">-1</field>
+        <field name="interval_type">days</field>
+        <field name="interval_number">1</field>
+        <field name="nextcall">2023-01-01 00:30</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="hr_attendance.model_hr_attendance" />
+        <field name="code">model._overtime_from_theoretical_time()</field>
+    </record>
+</odoo>

--- a/verdigado_attendance/migrations/15.0.1.0.1/post-migration.py
+++ b/verdigado_attendance/migrations/15.0.1.0.1/post-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2023 Hunki Enterprises BV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version=None):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env["hr.attendance.overtime"].search([]).unlink()
+    env["hr.attendance"].search([])._compute_theoretical_hours()
+    env["hr.attendance"]._overtime_from_theoretical_time()

--- a/verdigado_attendance/models/hr_attendance.py
+++ b/verdigado_attendance/models/hr_attendance.py
@@ -9,3 +9,83 @@ from odoo import models
 
 class HrAttendance(models.Model):
     _inherit = "hr.attendance"
+
+    def _update_overtime(self, employee_attendance_dates=None):
+        """Compute overtime from theoretical time"""
+        report = self.env["hr.attendance.theoretical.time.report"]
+        for this in self:
+            day_start_utc, date = self._get_day_start_and_day(
+                this.employee_id, this.check_in
+            )
+            overtime = (
+                self.env["hr.attendance.overtime"]
+                .search(
+                    [
+                        ("employee_id", "=", this.employee_id.id),
+                        ("date", "=", date),
+                        ("adjustment", "=", False),
+                    ]
+                )
+                .sudo()
+            )
+            if not overtime:
+                duration = this.worked_hours - report._theoretical_hours(
+                    this.employee_id, date
+                )
+                self.env["hr.attendance.overtime"].create(
+                    {
+                        "employee_id": this.employee_id.id,
+                        "date": date,
+                        "duration": duration,
+                        "duration_real": duration,
+                    }
+                )
+            else:
+                overtime.write(
+                    {
+                        "duration": overtime.duration + this.worked_hours,
+                        "duration_real": overtime.duration + this.worked_hours,
+                    }
+                )
+
+    def _overtime_from_theoretical_time(self):
+        """
+        Write missing overtime records based on hr_attendance_theoretical_time_report
+        Generate records up until yesterday to avoid interfering with today's time recording
+        """
+        self.env.cr.execute(
+            """
+            select
+                r.employee_id, r.date, sum(coalesce(r.theoretical_hours, 0)),
+                sum(r.worked_hours), sum(r.difference)
+            from hr_attendance_theoretical_time_report r
+            left join hr_attendance_overtime o
+                on r.employee_id=o.employee_id and r.date=o.date and not o.adjustment
+            where o.id is null and r.date < now()::date
+            group by r.employee_id, r.date
+            """
+        )
+        create_list = []
+        report = self.env["hr.attendance.theoretical.time.report"]
+        for (
+            employee_id,
+            date,
+            theoretical_hours,
+            worked_hours,
+            difference,
+        ) in self.env.cr.fetchall():
+            employee = self.env["hr.employee"].browse(employee_id)
+            duration = (
+                difference
+                if theoretical_hours > 0
+                else ((worked_hours or 0) - report._theoretical_hours(employee, date))
+            )
+            create_list.append(
+                {
+                    "employee_id": employee_id,
+                    "date": date,
+                    "duration": duration,
+                    "duration_real": duration,
+                }
+            )
+        return self.env["hr.attendance.overtime"].create(create_list)

--- a/verdigado_attendance/tests/__init__.py
+++ b/verdigado_attendance/tests/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2023 Hunki Enterprises BV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from . import test_overtime_calculation

--- a/verdigado_attendance/tests/test_overtime_calculation.py
+++ b/verdigado_attendance/tests/test_overtime_calculation.py
@@ -1,0 +1,147 @@
+# Copyright 2023 Hunki Enterprises BV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from datetime import date, datetime, timedelta
+
+from odoo.tests.common import TransactionCase
+
+
+class TestOvertimeCalculation(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.calendar = cls.env["resource.calendar"].create(
+            {
+                "name": "workdays morning",
+                "attendance_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "mon morning",
+                            "dayofweek": "0",
+                            "hour_from": 8,
+                            "hour_to": 12,
+                            "day_period": "morning",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "tue morning",
+                            "dayofweek": "1",
+                            "hour_from": 8,
+                            "hour_to": 12,
+                            "day_period": "morning",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "wed morning",
+                            "dayofweek": "2",
+                            "hour_from": 8,
+                            "hour_to": 12,
+                            "day_period": "morning",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "thu morning",
+                            "dayofweek": "3",
+                            "hour_from": 8,
+                            "hour_to": 12,
+                            "day_period": "morning",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "fri morning",
+                            "dayofweek": "4",
+                            "hour_from": 8,
+                            "hour_to": 12,
+                            "day_period": "morning",
+                        },
+                    ),
+                ],
+            }
+        )
+        cls.employee = cls.env["hr.employee"].create(
+            {
+                "name": "testemployee",
+                "resource_calendar_id": cls.calendar.id,
+            }
+        )
+        overtime_start = date.today() - timedelta(days=8)
+        cls.employee.company_id.overtime_start_date = overtime_start
+        cls.employee.theoretical_hours_start_date = overtime_start
+        cls.env.cr.flush()
+        cls.env["hr.attendance"]._overtime_from_theoretical_time()
+
+    def _get_theoretical_time(self, employee):
+        return self.env["hr.attendance.theoretical.time.report"].read_group(
+            [("employee_id", "=", employee.id), ("date", "<", date.today())],
+            ["theoretical_hours:sum", "worked_hours:sum", "difference:sum"],
+            ["employee_id"],
+        )[0]
+
+    def test_calculation_standard(self):
+        """Test that the calculation works as expected for standard cases"""
+        theoretical_hours = self._get_theoretical_time(self.employee)
+        self.assertEqual(
+            theoretical_hours["difference"],
+            -20,
+            "Worked 0h last week while it should be 20",
+        )
+        self.assertEqual(
+            self.employee.total_overtime,
+            -20,
+            "Worked 0h last week while it should be 20",
+        )
+
+        start_date = datetime.combine(
+            self.employee.company_id.overtime_start_date, datetime.min.time()
+        )
+        self.env["hr.attendance"].create(
+            {
+                "employee_id": self.employee.id,
+                "check_in": start_date + timedelta(days=1, hours=8),
+                "check_out": start_date + timedelta(days=1, hours=12),
+            }
+        )
+        self.env.cr.flush()
+        theoretical_hours = self._get_theoretical_time(self.employee)
+        self.assertEqual(
+            theoretical_hours["difference"],
+            -16,
+            "Worked 4h last week while it should be 20",
+        )
+        self.assertEqual(
+            self.employee.total_overtime,
+            -16,
+            "Worked 4h last week while it should be 20",
+        )
+        self.env["hr.attendance"].create(
+            {
+                "employee_id": self.employee.id,
+                "check_in": start_date + timedelta(days=1, hours=13),
+                "check_out": start_date + timedelta(days=1, hours=17),
+            }
+        )
+        self.env.cr.flush()
+        theoretical_hours = self._get_theoretical_time(self.employee)
+        self.assertEqual(
+            theoretical_hours["difference"],
+            -12,
+            "Worked 8h last week while it should be 20",
+        )
+        self.assertEqual(
+            self.employee.total_overtime,
+            -12,
+            "Worked 8h last week while it should be 20",
+        )


### PR DESCRIPTION
*Achtung, das ist noch PoC*

Ich habe hier ein Migrationsscript zugefügt das alle bestehenden Überstunden löscht und mit dem neuen Mechanismus neu berechnet. Nach dem Update sollte also für alle Mitarbeiter für alle Arbeitstage seit Kalenderbeginn ein record in der `hr.attendance.overtime`-Tabelle mit dem korrekten Wert bestehen.

Wichtig hier ist dass der cronjob jeden Tag morgens läuft, das erzeugt die fehlenden Stunden von gestern (bzw. alle fehlenden Stunden, es ist also kein Problem wenn der job an einem Tag nicht läuft)

Was noch fehlt ist die Überstunden neu berechnen wenn Werte verändert werden:

- [ ] vergangene Urlaube
- [ ] der Arbeitskalender
- [ ] vergangene Feiertage