### PR TITLE
[ADD] allow adding calendar links to time off calendar, default icals

### DIFF
--- a/verdigado_attendance/__manifest__.py
+++ b/verdigado_attendance/__manifest__.py
@@ -10,6 +10,7 @@
     "license": "AGPL-3",
     "installable": True,
     "depends": [
+        "base_ical",
         "hr_attendance",
         "hr_attendance_autoclose",
         "hr_attendance_break",
@@ -19,10 +20,12 @@
         "hr_holidays_public_overtime",
     ],
     "data": [
+        "data/base_ical.xml",
         "data/hr_leave_type.xml",
         "data/res.lang.csv",
         "security/verdigado_attendance.xml",
         "security/ir.model.access.csv",
+        "views/base_ical.xml",
         "views/hr_attendance_view.xml",
         "views/hr_attendance_report.xml",
         "views/hr_leave_type.xml",
@@ -42,10 +45,12 @@
         "web.assets_backend": [
             "verdigado_attendance/static/src/scss/backend.scss",
             "verdigado_attendance/static/src/js/systray.esm.js",
+            "verdigado_attendance/static/src/js/time_off_calendar.js",
         ],
         "web.assets_qweb": [
             "verdigado_attendance/static/src/xml/hr_holidays.xml",
             "verdigado_attendance/static/src/xml/systray.xml",
+            "verdigado_attendance/static/src/xml/time_off_calendar.xml",
         ],
     },
 }

--- a/verdigado_attendance/data/base_ical.xml
+++ b/verdigado_attendance/data/base_ical.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="ical_my_leaves" model="base.ical">
+        <field name="name">My leaves</field>
+        <field name="model_id" ref="hr_holidays.model_hr_leave" />
+        <field name="domain">[('user_id', '=', user.id)]</field>
+        <field name="expression_uid">str(record.id)</field>
+        <!-- prettier-ignore-start -->
+        <field name="expression_dtstart">(record.request_unit_half or record.request_unit_hours) and record.date_from or record.date_from.date()</field>
+        <field name="expression_dtend">(record.request_unit_half or record.request_unit_hours) and record.date_to or (record.date_to.date() + timedelta(days=1))</field>
+        <!-- prettier-ignore-end -->
+        <field name="expression_summary">
+            '%s: %s' % (record.employee_id.name, record.holiday_status_id.name)
+        </field>
+        <field name="auto" eval="True" />
+        <field name="show_on_holiday_calendar" eval="True" />
+    </record>
+    <record id="ical_my_team_leaves" model="base.ical">
+        <field name="name">My team leaves</field>
+        <field name="model_id" ref="hr_holidays.model_hr_leave" />
+        <field name="domain">[]</field>
+        <field name="expression_uid">str(record.id)</field>
+        <!-- prettier-ignore-start -->
+        <field name="expression_dtstart">(record.request_unit_half or record.request_unit_hours) and record.date_from or record.date_from.date()</field>
+        <field name="expression_dtend">(record.request_unit_half or record.request_unit_hours) and record.date_to or (record.date_to.date() + timedelta(days=1))</field>
+        <!-- prettier-ignore-end -->
+        <field name="expression_summary">
+            '%s: %s' % (record.employee_id.name, record.holiday_status_id.name)
+        </field>
+        <field name="auto" eval="True" />
+        <field name="show_on_holiday_calendar" eval="True" />
+    </record>
+</odoo>

--- a/verdigado_attendance/models/__init__.py
+++ b/verdigado_attendance/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
+from . import base_ical
 from . import hr_attendance
 from . import hr_attendance_break
 from . import hr_attendance_overtime

--- a/verdigado_attendance/models/base_ical.py
+++ b/verdigado_attendance/models/base_ical.py
@@ -1,0 +1,11 @@
+# Copyright 2023 Hunki Enterprises BV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0)
+
+
+from odoo import fields, models
+
+
+class BaseIcal(models.Model):
+    _inherit = "base.ical"
+
+    show_on_holiday_calendar = fields.Boolean("Show on holiday calendar")

--- a/verdigado_attendance/static/src/js/time_off_calendar.js
+++ b/verdigado_attendance/static/src/js/time_off_calendar.js
@@ -1,0 +1,44 @@
+odoo.define("verdigado_attendance.time_off_calendar", function (require) {
+    "use strict";
+
+    var viewRegistry = require("web.view_registry");
+    // Even though core doesn't return anything here, we need the require for correct dependencies
+    require("hr_holidays.dashboard.view_custo");
+
+    viewRegistry.get("time_off_calendar_all").prototype.config.Renderer.include({
+        _render: function () {
+            var self = this;
+            return this._super.apply(this, arguments).then(function () {
+                return self
+                    ._rpc({
+                        model: "base.ical",
+                        method: "search_read",
+                        args: [
+                            [["show_on_holiday_calendar", "=", true]],
+                            ["user_active", "user_url", "name"],
+                        ],
+                        context: self.state.context,
+                    })
+                    .then(function (ical_calendars) {
+                        var $links = self.$(".ical_links");
+                        if (ical_calendars.length === 0) {
+                            $links.hide();
+                        } else {
+                            $links.children("a").remove();
+                            $links.children("br").remove();
+                            _.chain(ical_calendars)
+                                .filter("user_active")
+                                .each(function (ical) {
+                                    var $a = jQuery(
+                                        '<a href="' + ical.user_url + '"/>'
+                                    );
+                                    $a.text(ical.name);
+                                    $links.append($a);
+                                    $links.append("<br/>");
+                                });
+                        }
+                    });
+            });
+        },
+    });
+});

--- a/verdigado_attendance/static/src/xml/time_off_calendar.xml
+++ b/verdigado_attendance/static/src/xml/time_off_calendar.xml
@@ -1,0 +1,10 @@
+<templates>
+    <t t-extend="TimeOff.CalendarView.extend">
+        <t t-jquery="div.o_timeoff_legend" t-operation="after">
+            <div class="ical_links">
+                <h5>Calendar links</h5>
+                <ul />
+            </div>
+        </t>
+    </t>
+</templates>

--- a/verdigado_attendance/views/base_ical.xml
+++ b/verdigado_attendance/views/base_ical.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2023 Hunki Enterprises BV
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl-3.0) -->
+<data>
+    <record id="view_base_ical_form" model="ir.ui.view">
+        <field name="model">base.ical</field>
+        <field name="inherit_id" ref="base_ical.view_base_ical_form" />
+        <field name="arch" type="xml">
+            <field name="auto" position="after">
+                <field name="show_on_holiday_calendar" />
+            </field>
+        </field>
+    </record>
+</data>


### PR DESCRIPTION
in https://github.com/OCA/server-backend/pull/231 habe ich ein auto-flag hinzugefügt, mit dem ein Kalender fur alle user aktiviert wird (sie können das von Hand wieder deaktivieren).

Hier gibt es ein flag um bestimmte Kalender im Leave-Kalender anzuzeigen, die Links erscheinen dann unter der Legende.

Weiterhin definiere ich zwei Standardkalender die automatisch aktiviert sind und in der Kalender-Ansicht angezeigt werden.

Diskussion:

1. 'Mein Team' habe ich jetzt definiert als 'In meiner Abteilung', das muss ggf noch verändert werden
2. Statt nur dem Link vielleicht besser wenn ein Click die URL in die Zwischenablage kopiert und das in einem Popup sagt?