### PR TITLE
[ADD] #40 hide the generic vacation wizard to only show the de-specific one

### DIFF
--- a/verdigado_attendance/__manifest__.py
+++ b/verdigado_attendance/__manifest__.py
@@ -27,6 +27,7 @@
         "views/hr_attendance_report.xml",
         "views/hr_leave_type.xml",
         "views/hr_menu_human_resources_configuration.xml",
+        "views/menu.xml",
     ],
     "demo": [
         "demo/res_users.xml",

--- a/verdigado_attendance/views/menu.xml
+++ b/verdigado_attendance/views/menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record
+        id="hr_holidays_public.menu_create_next_year_public_holidays"
+        model="ir.ui.menu"
+    >
+        <field name="groups_id" eval="[(6, 0, [ref('base.group_no_one')])]" />
+    </record>
+</odoo>


### PR DESCRIPTION
CI ist in https://github.com/verdigado/odoo-customize/pull/53 repariert

Ungewunschte Dinge in den debug-Modus zu stecken hat den Vorteil dass das dann doch noch einfach zugänglich ist falls das doch aus welchen Gründen auch immer mal gebraucht wird.