### PR TITLE
[ADD] fix for #88, tests for consistency

### DIFF
--- a/repos.yml
+++ b/repos.yml
@@ -6,10 +6,13 @@ hr:
 hr-attendance:
     remotes:
         oca: https://github.com/OCA/hr-attendance.git
+        hbrunn: https://github.com/hbrunn/hr-attendance.git
     merges:
         - oca 15.0
         # https://github.com/OCA/hr-attendance/pull/140
         - oca refs/pull/140/head
+        # PR on the above
+        - hbrunn 15.0-hr_attendance_missing_days
         # https://github.com/OCA/hr-attendance/pull/141
         - oca refs/pull/141/head
         # https://github.com/OCA/hr-attendance/pull/142

--- a/verdigado_attendance/tests/test_overtime_calculation.py
+++ b/verdigado_attendance/tests/test_overtime_calculation.py
@@ -138,6 +138,11 @@ class TestOvertimeCalculation(TransactionCase):
         attendance.check_out += timedelta(hours=1)
         self.assertOvertime(employeeA, "2023-08-06", 9 * 60, 0)
 
+        # be sure that a day spanning attendance generates overtime records for all days
+        attendance.check_out += timedelta(days=1)
+        self.assertOvertime(employeeA, "2023-08-06", 33 * 60, 0)
+        self.assertOvertime(employeeA, "2023-08-07", 0, 8 * 60)
+
     def to_time(self, time_string):
         if isinstance(time_string, str):
             return datetime.strptime(time_string, "%H:%M:%S").time()


### PR DESCRIPTION
das konfliktet mit #81, kannst Du also nicht gleichzeitig testen ohne die Konflikte lokal aufzulösen (ich rebase dann wenn eins davon gemerged ist).

Findest Du es auch akzeptabel dass die Überstunden fur die ganze Arbeitszeit am Beginntag anfallen? Ansonsten muss ich die Zeit auf die Tage verteilen, das erhöht die Komplexität (aber möglich natürlich).

Der test case ist ohnehin interessant, es beginnt am Sonntag und geht in den Montag rein. Da finde ich es selbst logisch dass das als Sontagsarbeit gilt (mit entsprechendem Multiplikator falls eingestellt), und nicht die Zeit in der Nacht zum Montag nach 00:00 als frühe Montagsarbeit gezahlt wird. Da hat das Arbeitsrecht doch sicher eine Meinung zu?