### PR TITLE
[ADD] allow adding the attendance widget to dashboards

### DIFF
--- a/verdigado_attendance/__manifest__.py
+++ b/verdigado_attendance/__manifest__.py
@@ -62,6 +62,7 @@
         ],
         "web.assets_backend": [
             "verdigado_attendance/static/src/scss/backend.scss",
+            "verdigado_attendance/static/src/js/board_renderer.js",
             "verdigado_attendance/static/src/js/hr_attendance.js",
             "verdigado_attendance/static/src/js/systray.esm.js",
             "verdigado_attendance/static/src/js/time_off_calendar.js",

--- a/verdigado_attendance/static/src/js/board_renderer.js
+++ b/verdigado_attendance/static/src/js/board_renderer.js
@@ -1,0 +1,24 @@
+odoo.define("verdigado_attendance.BoadRenderer", function (require) {
+    "use strict";
+    var BoardView = require("board.BoardView");
+    var core = require("web.core");
+
+    BoardView.prototype.config.Renderer.include({
+        _createController: function (params) {
+            if (params.viewType === "hr_attendance_my_attendances") {
+                var client_action = core.action_registry.get(
+                    "hr_attendance_my_attendances"
+                );
+                var attendances = new client_action(this, {}, {});
+                attendances.do_action = function () {
+                    params.$node.empty();
+                    return attendances.appendTo(params.$node).then(function () {
+                        return attendances.willStart();
+                    });
+                };
+                return attendances.appendTo(params.$node);
+            }
+            return this._super.apply(this, arguments);
+        },
+    });
+});

--- a/verdigado_attendance/static/src/js/hr_attendance.js
+++ b/verdigado_attendance/static/src/js/hr_attendance.js
@@ -5,8 +5,13 @@ odoo.define("verdigado_attendance.hr_attendance", function (require) {
     "use strict";
 
     var myAttendances = require("hr_attendance.my_attendances");
+    var core = require("web.core");
 
     myAttendances.include({
+        events: _.extend(myAttendances.prototype.events, {
+            "click a.add_to_dashboard": "_add_to_dashboard",
+        }),
+
         willStart: function () {
             var self = this;
             var promise = this._rpc({
@@ -17,6 +22,7 @@ odoo.define("verdigado_attendance.hr_attendance", function (require) {
             });
             return Promise.all([this._super.apply(this, arguments), promise]);
         },
+
         _rpc: function (params) {
             if (
                 params &&
@@ -28,6 +34,19 @@ odoo.define("verdigado_attendance.hr_attendance", function (require) {
                 ).is(":checked");
             }
             return this._super.apply(this, arguments);
+        },
+
+        _add_to_dashboard: function () {
+            return this._rpc({
+                route: "/board/add_to_dashboard",
+                params: {
+                    action_id: -1,
+                    context_to_save: {},
+                    domain: [],
+                    view_mode: "hr_attendance_my_attendances",
+                    name: core._t("Check In / Check Out"),
+                },
+            });
         },
     });
 });

--- a/verdigado_attendance/static/src/scss/backend.scss
+++ b/verdigado_attendance/static/src/scss/backend.scss
@@ -35,3 +35,26 @@ span[data-menu-xmlid="mail.menu_root_discuss"] {
         background-color: #e7f7eb !important;
     }
 }
+
+/* adapt display of attendance client action within dashboard */
+.oe_dashboard .o_hr_attendance_kiosk_mode_container {
+    position: relative;
+    margin-top: 90px;
+}
+
+.oe_dashboard .o_hr_attendance_kiosk_backdrop {
+    background: none;
+}
+
+/* hide add to dashboard link without mouseover */
+.o_hr_attendance_user_badge .add_to_dashboard {
+    display: none;
+}
+.o_hr_attendance_user_badge:hover .add_to_dashboard {
+    display: block;
+    color: white;
+}
+
+.oe_dashboard .o_hr_attendance_user_badge:hover .add_to_dashboard {
+    display: none;
+}

--- a/verdigado_attendance/static/src/xml/hr_attendance.xml
+++ b/verdigado_attendance/static/src/xml/hr_attendance.xml
@@ -12,5 +12,8 @@
                 </label>
             </div>
         </xpath>
+        <xpath expr="//div[hasclass('o_hr_attendance_user_badge')]" position="inside">
+            <a class="add_to_dashboard" href="#">Add to dashboard</a>
+        </xpath>
     </t>
 </templates>


### PR DESCRIPTION
@albig hier eine erste benutzbare Version, das braucht aber noch etwas Feinschliff:

- zur Zeit musst Du das von Hand zufügen in *Settings/Technical/User Interface/Customized Views*: dort die oberste (=neuste) Dashboard-View deines Testbenutzers suchen, und hier innerhalb eines column-tags ein action-Tag setzen: `<action name="0" string="Checkin" view_mode="hr_attendance_my_attendances"/>` (`string` ist arbitrar, name ist auch egal aber muss als int parsbar sein, und view_mode bestimmt dass es sich hier um das attendance-widget handelt)
- ich zeige zur Zeit nicht die Zusammenfassung an die das Original ein paar Sekunden zeigt bevor es auf die Knöpfe schaltet. Kann auch als Feature gesehen werden, und das richtig zu machen braucht viel mehr Logik im Code, daher lasse ich euch erstmal so drauf schauen.

Bis zum Meeting sollte ich den Zum-Dashboard-Hinzufügen Knopf fertig haben, und dann können wir den anderen Punkt besprechen.

Ist es ggf sinnvoll dann auch darüber zu reden wie die Dashboards auszurollen? In eurem Fall kann ich mir vorstellen dass ein Standard-Dashboard pro Verdigado-Gruppe ein guter Anfang ist, und von da aus können sich die User das selbst einstellen? Bleibt dann noch die Frage wie mit updates umgehen, lassen wir ein selbstdefiniertes Board in Ruhe wenn sich die Defaults ändern, oder versuchen wir eine Art diff update?